### PR TITLE
Unbreak cloud-agent's cms build on newer LibreSSL (OpenBSD 6.5)

### DIFF
--- a/cms/lib/cms.h
+++ b/cms/lib/cms.h
@@ -80,7 +80,7 @@ DECLARE_ASN1_FUNCTIONS(CMS_ContentInfo)
 DECLARE_ASN1_FUNCTIONS(CMS_ReceiptRequest)
 DECLARE_ASN1_PRINT_FUNCTION(CMS_ContentInfo)
 
-#if LIBRESSL_VERSION_NUMBER >= 0x20900000L
+#if defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x20900000L
 #define M_ASN1_new_of(type) 				\
 	(type *)ASN1_item_new(ASN1_ITEM_rptr(type))
 #define M_ASN1_free_of(x, type) 			\

--- a/cms/lib/cms.h
+++ b/cms/lib/cms.h
@@ -80,6 +80,13 @@ DECLARE_ASN1_FUNCTIONS(CMS_ContentInfo)
 DECLARE_ASN1_FUNCTIONS(CMS_ReceiptRequest)
 DECLARE_ASN1_PRINT_FUNCTION(CMS_ContentInfo)
 
+#if LIBRESSL_VERSION_NUMBER >= 0x20900000L
+#define M_ASN1_new_of(type) 				\
+	(type *)ASN1_item_new(ASN1_ITEM_rptr(type))
+#define M_ASN1_free_of(x, type) 			\
+	ASN1_item_free(CHECKED_PTR_OF(type, x), ASN1_ITEM_rptr(type))
+#endif
+
 # define CMS_SIGNERINFO_ISSUER_SERIAL    0
 # define CMS_SIGNERINFO_KEYIDENTIFIER    1
 


### PR DESCRIPTION
Fix from @xenotrope