### PR TITLE
Allow to specify the probed cloud stacks with -c cloud[,cloud...]

### DIFF
--- a/agent/cloud-agent.8
+++ b/agent/cloud-agent.8
@@ -23,6 +23,7 @@
 .Sh SYNOPSIS
 .Nm cloud-agent
 .Op Fl nuv
+.Op Fl c Ar cloud Ns Op , Ns Ar cloud Ns ...
 .Op Fl p Ar length
 .Op Fl r Ar rootdisk
 .Op Fl t Ar timeout
@@ -32,10 +33,31 @@
 The
 .Nm
 program manages the OpenBSD provisioning and VM interaction in cloud
-environments, including Microsoft Azure and Amazon AWS.
+environments.
 .Pp
 The options are as follows:
 .Bl -tag -width Ds
+.It Fl c Ar cloud Ns Op , Ns Ar cloud Ns ...
+Probe a list of cloud stacks for provisioning in the specified order.
+If this option is not specified,
+.Nm
+tries to detect the environment and possible cloud stacks automatically.
+Supported
+.Ar cloud
+stacks are:
+.Pp
+.Bl -tag -width opennebula -offset indent -compact
+.It Ic azure
+Microsoft Azure
+.It Ic cloudinit
+Generic cloud-init
+.It Ic ec2
+Amazon AWS EC2
+.It Ic opennebula
+OpenNebula
+.It Ic openstack
+OpenStack
+.El
 .It Fl p Ar length
 Generate and set a random password for the default user.
 The password will be written in its plain form into the

--- a/agent/cloudinit.c
+++ b/agent/cloudinit.c
@@ -32,64 +32,28 @@
 static int	 cloudinit_fetch(struct system_config *);
 
 int
-tryendpoint(struct system_config *sc,
-    int (fetch)(struct system_config *),
-    int (next)(struct system_config *))
-{
-	int	 errfd = -1, ret;
-
-	free(sc->sc_endpoint);
-	sc->sc_endpoint = NULL;
-
-	switch (sc->sc_dhcpendpoint) {
-	case 0:
-		sc->sc_dhcpendpoint = 1;
-		if (dhcp_getendpoint(sc) == -1)
-			return tryendpoint(sc, fetch, next);
-		break;
-	case 1:
-		sc->sc_dhcpendpoint = 2;
-		if ((sc->sc_endpoint = strdup(DEFAULT_ENDPOINT)) == NULL) {
-			log_warnx("failed to set defaults");
-			return (-1);
-		}
-		break;
-	default:
-		if (next == NULL)
-			return (-1);
-		sc->sc_dhcpendpoint = 0;
-		return (*next)(sc);
-	}
-
-	errfd = disable_output(sc, STDERR_FILENO);
-	ret = (*fetch)(sc);
-	enable_output(sc, STDERR_FILENO, errfd);
-	if (ret != 0)
-		return tryendpoint(sc, fetch, next);
-
-	return (0);
-}
-
-int
 ec2(struct system_config *sc)
 {
-	free(sc->sc_username);
-	if ((sc->sc_username = strdup("ec2-user")) == NULL) {
-		log_warnx("failed to set default user");
+	if (sc->sc_state == STATE_INIT) {
+		free(sc->sc_username);
+		if ((sc->sc_username = strdup("ec2-user")) == NULL) {
+			log_warnx("failed to set default user");
+			return (-1);
+		}
+		sc->sc_state = STATE_169;
 		return (-1);
 	}
-
-	sc->sc_stack = "ec2";
-	sc->sc_dhcpendpoint = 1;
-	return tryendpoint(sc, cloudinit_fetch, NULL);
+	return cloudinit_fetch(sc);
 }
 
 int
 cloudinit(struct system_config *sc)
 {
-	sc->sc_stack = "cloudinit";
-	sc->sc_dhcpendpoint = 0;
-	return tryendpoint(sc, cloudinit_fetch, NULL);
+	if (sc->sc_state == STATE_INIT) {
+		sc->sc_state = STATE_DHCP;
+		return (-1);
+	}
+	return cloudinit_fetch(sc);
 }
 
 static int

--- a/agent/opennebula.c
+++ b/agent/opennebula.c
@@ -40,11 +40,14 @@ opennebula(struct system_config *sc)
 	int		 ret = -1;
 	unsigned short	 unit;
 
+	if (sc->sc_state == STATE_INIT) {
+		sc->sc_state = STATE_169;
+		return (-1);
+	}
+
 	/* Return silently without error */
 	if ((fp = fopen("/mnt/context.sh", "r")) == NULL)
 		goto done;
-
-	sc->sc_stack = "opennebula";
 
 	while ((line = fparseln(fp, &len, &lineno,
 	    delim, FPARSELN_UNESCALL)) != NULL) {

--- a/agent/openstack.c
+++ b/agent/openstack.c
@@ -31,11 +31,14 @@
 
 static int	 openstack_fetch(struct system_config *);
 
-
 int
 openstack(struct system_config *sc)
 {
-	return tryendpoint(sc, openstack_fetch, cloudinit);
+	if (sc->sc_state == STATE_INIT) {
+		sc->sc_state = STATE_DHCP;
+		return (-1);
+	}
+	return openstack_fetch(sc);
 }
 
 static int
@@ -53,7 +56,6 @@ openstack_fetch(struct system_config *sc)
 	if ((json = metadata(sc,
 	    "/openstack/latest/meta_data.json", TEXT)) == NULL)
 		goto fail;
-	sc->sc_stack = "openstack";
 
 	if ((j = json_parse(json, strlen(json))) == NULL)
 		goto fail;


### PR DESCRIPTION
cloud-agent tries to auto-detect the cloud environment and probes possible stacks.

The -c option allows to overwrite the default automatic probe order, for example to use OpenStack in Hyper-V:

```
# cloud-agent -c azure,openstack,cloudinit hvn0
```